### PR TITLE
updated few functions & bug fixes

### DIFF
--- a/types/event.ts
+++ b/types/event.ts
@@ -4,10 +4,3 @@ export type WalletActivityEvent = {
   timestamp: number;
   cluster?: string[];
 };
-
-export type Signal = {
-  type: string;
-  payload: any;
-  timestamp: number;
-  source: string;
-};

--- a/types/signal.ts
+++ b/types/signal.ts
@@ -3,6 +3,39 @@ export type Signal = {
   hash: string;
   timestamp: string;
   source: string;
+  confidence?: number; // Optional confidence score (0-1)
 };
 
-// TODO: add error handling for malformed signal payloads
+/**
+ * Validates that a signal object has all required fields and valid values
+ */
+export function validateSignal(signal: any): signal is Signal {
+  if (!signal || typeof signal !== 'object') {
+    return false;
+  }
+
+  // Check required fields
+  if (typeof signal.type !== 'string' || signal.type.trim() === '') {
+    return false;
+  }
+  if (typeof signal.hash !== 'string' || signal.hash.trim() === '') {
+    return false;
+  }
+  if (typeof signal.timestamp !== 'string' || signal.timestamp.trim() === '') {
+    return false;
+  }
+  if (typeof signal.source !== 'string' || signal.source.trim() === '') {
+    return false;
+  }
+
+  // Validate optional confidence score
+  if (signal.confidence !== undefined) {
+    if (typeof signal.confidence !== 'number' ||
+      signal.confidence < 0 ||
+      signal.confidence > 1) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -4,9 +4,14 @@ export function logSignal(signal: {
   glyph: string;
   hash: string;
   timestamp: string;
+  confidence?: number;
   details?: Record<string, any>;
 }) {
-  console.log(`[${signal.agent}] stored signal ${signal.hash} (${signal.type}) at ${signal.timestamp}`);
+  const confidenceStr = signal.confidence !== undefined
+    ? ` confidence: ${signal.confidence.toFixed(2)}`
+    : '';
+
+  console.log(`[${signal.agent}] stored signal ${signal.hash} (${signal.type})${confidenceStr} at ${signal.timestamp}`);
   if (signal.details) {
     console.log(`├─ context:`, JSON.stringify(signal.details, null, 2));
   }

--- a/utils/signal.ts
+++ b/utils/signal.ts
@@ -1,5 +1,22 @@
+import { validateSignal } from "../types/signal";
+import { logAgentError } from "./error";
+
 export function generateSignalHash(event: any): string {
   const base = JSON.stringify(event) + Date.now();
-  const hash = Buffer.from(base).toString("base64").slice(0, 10);
+  const hash = btoa(base).slice(0, 10); // using btoa instead of Buffer for browser compatibility
   return "sig_" + hash;
+}
+
+/**
+ * Safely validates and processes a signal before emission
+ * @param signal The signal to validate
+ * @param agentName Name of the agent for error logging
+ * @returns true if signal is valid, false otherwise
+ */
+export function validateAndLogSignal(signal: any, agentName: string): boolean {
+  if (!validateSignal(signal)) {
+    logAgentError(agentName, new Error(`Invalid signal format: ${JSON.stringify(signal)}`));
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
## Problems Fixed
Missing confidence field - Agents were passing confidence scores but Signal type didn't include it
Unresolved TODO - Added signal validation for malformed payloads (types/signal.ts line 8)
Duplicate Signal types - Removed conflicting definition from types/event.ts
Logger ignoring confidence - Confidence scores weren't displayed in logs
Buffer dependency error - Fixed TypeScript error with cross-platform solution

---

## Changes Made

1. Types Fixed

```typescript
// Added missing confidence field + validation
export type Signal = {
  type: string;
  hash: string; 
  timestamp: string;
  source: string;
  confidence?: number; // NEW: Optional 0-1 score
};
```

2. Signal Validation Added

```typescript
export function validateSignal(signal: any): signal is Signal
export function validateAndLogSignal(signal: any, agentName: string): boolean
```

3. Logger Enhanced

```
// Before: [Agent] stored signal sig_abc (type) at timestamp
// After:  [Agent] stored signal sig_abc (type) confidence: 0.91 at timestamp
```
---

## Files Changed

types/signal.ts - Added confidence field + validation
types/event.ts - Removed duplicate Signal type
utils/logger.ts - Display confidence in logs
utils/signal.ts - Added validation helper + fixed Buffer

---